### PR TITLE
Removes shortened URL for git.io deprecation

### DIFF
--- a/src/Flipcard.js
+++ b/src/Flipcard.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
-// Rewrite of mzabriskie/react-flipcard, MIT via https://git.io/vdKLa
-// Adds support for revolving-door transition, MIT via https://git.io/vdKc7
+// Rewrite of mzabriskie/react-flipcard, MIT via https://github.com/mzabriskie/react-flipcard
+// Adds support for revolving-door transition, MIT via https://github.com/AaronCCWong/react-card-flip
 
 class Flipcard extends React.Component {
   constructor(props) {


### PR DESCRIPTION
https://github.blog/changelog/2022-04-25-git-io-deprecation/